### PR TITLE
Fix query limit kwarg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 .env
 *.sqlite3
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv
 .env
 *.sqlite3
+*pyc
 .vscode

--- a/affirmations/main.py
+++ b/affirmations/main.py
@@ -38,7 +38,7 @@ def read_users(
     *,
     session: Session = Depends(get_session),
     offset: int = 0,
-    limit: int = Query(default=100, lte=100)
+    limit: int = Query(default=100, le=100)
 ):
     users = session.exec(select(User).offset(offset).limit(limit)).all()
     return users
@@ -83,7 +83,7 @@ def read_affirmations(
     *,
     session: Session = Depends(get_session),
     offset: int = 0,
-    limit: int = Query(default=100, lte=100)
+    limit: int = Query(default=100, le=100)
 ):
     affirmations = session.exec(select(Affirmation).offset(offset).limit(limit)).all()
     return affirmations


### PR DESCRIPTION
Changed `Query` kwarg from `lte` to `le` so that the validation works correctly in the Swagger UI